### PR TITLE
Relax version constraints for dependencies

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache 2.0'
 description 'Configures yum repository for Chef Software, Inc. products'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '0.2.0'
-depends 'yum', '~> 3.2'
+depends 'yum', '>= 3.2'
 
 %w(amazon centos fedora oracle redhat scientific).each do |os|
   supports os


### PR DESCRIPTION
We need to use >= instead of ~> for version constraints because Chef
Policies use "dotted decimal identifier" versions that result in
integers that will never match the "normal" cookbook versions we use.

For example, the version constraint:

~> 3.2

is what we used. However, the dotted decimal version may be

30625036585770760.42672982950081083.162968991950205

The dotted decimal version is used in the "backwards compatibility
mode" for Chef Zero as it doesn't have the native Policy document API
(yet). This may result in a 412 precondition failed exception when
using the pessmistic version constraint.