### PR TITLE
Allow baseurl to be overridable in stable and current recipes, like i…

### DIFF
--- a/recipes/current.rb
+++ b/recipes/current.rb
@@ -20,7 +20,7 @@
 
 yum_repository 'chef-current' do
   description 'Chef chef-current repository'
-  baseurl "https://packagecloud.io/chef/current/el/#{node['platform_version'].split('.').first}/$basearch"
+  baseurl node['yum-chef']['baseurl']
   gpgkey node['yum-chef']['gpgkey']
   sslcacert node['yum-chef']['sslcacert']
   proxy node['yum-chef']['proxy']

--- a/recipes/stable.rb
+++ b/recipes/stable.rb
@@ -20,7 +20,7 @@
 
 yum_repository 'chef-stable' do
   description 'Chef chef-stable repository'
-  baseurl "https://packagecloud.io/chef/stable/el/#{node['platform_version'].split('.').first}/$basearch"
+  baseurl node['yum-chef']['baseurl']
   gpgkey node['yum-chef']['gpgkey']
   sslcacert node['yum-chef']['sslcacert']
   proxy node['yum-chef']['proxy']


### PR DESCRIPTION
Allows the baseurl to be overwritten as an attribute in the current and stable recipes, like in the default recipe.  This allows for the override the baseurl so the cookbook will run on platforms such as amazon linux.