### PR TITLE
Chef 13 deprecations

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,7 +8,6 @@ platforms:
   - name: centos-5.11
   - name: centos-6.7
   - name: centos-7.1
-  - name: fedora-21
 
 suites:
   - name: default

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -20,12 +20,10 @@
 
 yum_repository node['yum-chef']['repositoryid'] do
   description "Chef #{node['yum-chef']['repositoryid']} repository"
-  baseurl node['yum-chef']['baseurl']
-  gpgkey node['yum-chef']['gpgkey']
-  sslcacert node['yum-chef']['sslcacert']
-  proxy node['yum-chef']['proxy']
-  proxy_username node['yum-chef']['proxy_username']
-  proxy_password node['yum-chef']['proxy_password']
+  node['yum-chef'].each_pair do |opt, val|
+    next if opt == 'repositoryid'
+    send(opt.to_sym, val) unless val.nil?
+  end
   sslverify true
   gpgcheck true
   action :create

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,1 +1,1 @@
-package 'chefdk'
+package 'chef-sync'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -5,7 +5,7 @@ describe 'yum-chef::default' do
     expect(file('/etc/yum.repos.d/chef-stable.repo')).to be_file
   end
 
-  it 'has the chefdk package installed' do
-    expect(package('chefdk')).to be_installed
+  it 'has the chef-sync package installed' do
+    expect(package('chef-sync')).to be_installed
   end
 end


### PR DESCRIPTION
fixes yum_repository resource's deprecation warnings re: passing `nil` as argument to resource attributes

also fixes issues encountered while trying to run tests: switch to installing a test package that is avail on EL 5, remove test platform not supported by chef repositories.