### PR TITLE
[JEX-112] Begin using packages.chef.io YUM repo

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,7 +23,7 @@ Metrics/AbcSize:
   Enabled: false
 PerceivedComplexity:
   Enabled: false
-SingleSpaceBeforeFirstArg:
+Style/SpaceBeforeFirstArg:
   Enabled: false
 Style/ClassAndModuleChildren:
   Enabled: false

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -23,7 +23,7 @@ node.default['yum-chef'].tap do |yum|
   # The baseurl setting for the repository. This is calculated using the major
   # number part of the node's platform version. Must be a supported major version.
   # See https://docs.chef.io/supported_platforms.html
-  yum['baseurl']        = "https://packagecloud.io/chef/stable/el/$releasever/$basearch"
+  yum['baseurl']        = 'https://packages.chef.io/stable-yum/el/$releasever/$basearch'
 
   # Use the local copy of the Chef public GPG key if we're on a Chef Server.
   # This is to preserve compatibility with the `chef-server-ctl install` command.

--- a/recipes/current.rb
+++ b/recipes/current.rb
@@ -19,8 +19,8 @@
 #
 
 yum_repository 'chef-current' do
-  description 'Chef chef-current repository'
-  baseurl "https://packagecloud.io/chef/current/el/#{node['platform_version'].split('.').first}/$basearch"
+  description 'Chef Software Inc current channel'
+  baseurl 'https://packages.chef.io/current-yum/el/$releasever/$basearch'
   gpgkey node['yum-chef']['gpgkey']
   sslcacert node['yum-chef']['sslcacert']
   proxy node['yum-chef']['proxy']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 #
 
 yum_repository node['yum-chef']['repositoryid'] do
-  description "Chef #{node['yum-chef']['repositoryid']} repository"
+  description "Chef Software Inc #{node['yum-chef']['repositoryid']} repository"
   node['yum-chef'].each_pair do |opt, val|
     next if opt == 'repositoryid'
     send(opt.to_sym, val) unless val.nil?

--- a/recipes/stable.rb
+++ b/recipes/stable.rb
@@ -19,8 +19,8 @@
 #
 
 yum_repository 'chef-stable' do
-  description 'Chef chef-stable repository'
-  baseurl "https://packagecloud.io/chef/stable/el/#{node['platform_version'].split('.').first}/$basearch"
+  description 'Chef Software Inc stable channel'
+  baseurl 'https://packages.chef.io/stable-yum/el/$releasever/$basearch'
   gpgkey node['yum-chef']['gpgkey']
   sslcacert node['yum-chef']['sslcacert']
   proxy node['yum-chef']['proxy']

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -38,7 +38,7 @@ describe 'yum-chef::default' do
     it 'renders the yum repository with defaults' do
       expect(chef_run).to create_yum_repository('chef-stable').with(
         repositoryid: 'chef-stable',
-        baseurl: 'https://packagecloud.io/chef/stable/el/7/$basearch'
+        baseurl: 'https://packages.chef.io/stable-yum/el/$releasever/$basearch'
       )
     end
   end


### PR DESCRIPTION
The existing PackageCloud YUM repo has been deprecated. The new YUM repos have equivalent versions for all products and should be a drop in replacement. See the following mailing list post for full details:
https://discourse.chef.io/t/we-ve-moved-our-software-distribution-to-packages-chef-io/8001

/cc @chef-cookbooks/engineering-services @tas50 